### PR TITLE
Fix makefile and add to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ Usage example:
 
 More information on: http://jordicenzano.name/2014/08/31/the-source-code-of-a-minimal-h264-encoder-c/
 
+
+Generating a YUV file
+A 10 second yuv file (SQCIF 128x96) with a test image can be made with this ffmpeg command
+> ffmpeg -f lavfi -i testsrc -t 10  -s sqcif -pix_fmt yuv420p AVsyncTest.yuv
+

--- a/src/makefile
+++ b/src/makefile
@@ -2,12 +2,12 @@
 # By Jordi Cenzano (www.jordicenzano.name)
 CC=g++
 CFLAGS=-c -Wall
-HEADERS = CJOCbitstream.h CJOCh264encoder.h
+HEADERS = CJOCh264bitstream.h CJOCh264encoder.h
 
 all: h264simpleCoder
 
-h264simpleCoder: h264simpleCoder.o CJOCh264encoder.o CJOCbitstream.o
-	$(CC) h264simpleCoder.o CJOCh264encoder.o CJOCbitstream.o -o h264simpleCoder
+h264simpleCoder: h264simpleCoder.o CJOCh264encoder.o CJOCh264bitstream.o
+	$(CC) h264simpleCoder.o CJOCh264encoder.o CJOCh264bitstream.o -o h264simpleCoder
 
 h264simpleCoder.o: h264simpleCoder.cpp $(HEADERS)
 	$(CC) $(CFLAGS) h264simpleCoder.cpp
@@ -15,8 +15,8 @@ h264simpleCoder.o: h264simpleCoder.cpp $(HEADERS)
 CJOCh264encoder.o: CJOCh264encoder.cpp $(HEADERS)
 	$(CC) $(CFLAGS) CJOCh264encoder.cpp
 
-CJOCbitstream.o: CJOCbitstream.cpp $(HEADERS)
-	$(CC) $(CFLAGS) CJOCbitstream.cpp
+CJOCh264bitstream.o: CJOCh264bitstream.cpp $(HEADERS)
+	$(CC) $(CFLAGS) CJOCh264bitstream.cpp
 
 clean:
 	rm -rf *o h264simpleCoder


### PR DESCRIPTION
The makefile was referring to the wrong filenames for the bitstream .h and .cpp files.
This pull request fixes the makefile.

I also added in an example to generate a test YUV image with ffmpeg in the Readme.