### PR TITLE
SPS Header and Slice Header Fixes

### DIFF
--- a/src/CJOCh264encoder.cpp
+++ b/src/CJOCh264encoder.cpp
@@ -149,10 +149,10 @@ void CJOCh264encoder::create_slice_header(unsigned long lFrameNum)
 	addexpgolombunsigned(7); // slice_type
 	addexpgolombunsigned(0); // pic_param_set_id
 
-	unsigned char cFrameNum = lFrameNum % 16; //(2⁴)
+	unsigned char cFrameNum = 0; // FrameNum=0 for IDR frames [otherwise lFrameNum % 16; //(2⁴)]
 	addbits (cFrameNum,4); // frame_num ( numbits = v = log2_max_frame_num_minus4 + 4)
 
-	unsigned long lidr_pic_id = lFrameNum % 512;
+	unsigned long lidr_pic_id = lFrameNum % 512; // could be % 65536 as valid range 0..65536
 	//idr_pic_flag = 1
 	addexpgolombunsigned(lidr_pic_id); // idr_pic_id
 	addbits(0x0,4); // pic_order_cnt_lsb (numbits = v = log2_max_fpic_order_cnt_lsb_minus4 + 4)

--- a/src/CJOCh264encoder.cpp
+++ b/src/CJOCh264encoder.cpp
@@ -106,7 +106,6 @@ void CJOCh264encoder::create_sps (int nImW, int nImH, int nMbW, int nMbH, int nF
 	addbits(0x0,1);  //bitstream_restriction_flag
 	//END VUI
 
-	addbits(0x0,1); // frame_mbs_only_flag
 	addbits(0x1,1); // rbsp stop bit
 
 	dobytealign();


### PR DESCRIPTION
These changes fix a bug in the SPS Header and a bug in the Slice header
The SPS Header has an extra bit set that is not needed
The Slice Header needs to set cFrameNum to Zero for IDR frames.
As every frame in simpleH264coder is an IDR frame then cFrameNum must be 0 all the time.